### PR TITLE
Update AppLayout.java  to make "add" method public

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -322,7 +322,7 @@ public class AppLayout extends Component implements RouterLayout, HasStyle {
         }
     }
 
-    private void add(Component component) {
+    public void add(Component component) {
         getElement().appendChild(component.getElement());
     }
 


### PR DESCRIPTION
There is no reason for the "add" method to be private since that creates an environment where creating unique layouts become restrictive without using reflection and causing a performance hit on the app. Please consider merging this change.

Thanks you for your time!

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE -->
<!-- PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
